### PR TITLE
Improve readability when text is highlighted

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -529,8 +529,7 @@ html, body {
     padding: 2px;
     margin: -3px;
     border-radius: 4px;
-    border: 1px solid #F7E633;
-    background: linear-gradient(to top left, #F7E633 0%, #F1D32F 100%);
+    border: 3px solid #ef0499;
   }
 }
 


### PR DESCRIPTION

## Before

Yellow background + white text = unreadable.

![Screenshot 2023-03-15 at 14 27 11](https://user-images.githubusercontent.com/396336/225323714-6070b002-5105-4f6a-acac-9ad48268a9b2.png)


## After

Pink outline + any colour text = always readable (hopefully).

![Screenshot 2023-03-15 at 14 26 06](https://user-images.githubusercontent.com/396336/225323762-68c78f7b-9160-4cd5-bceb-fae83fd41584.png)
